### PR TITLE
fix: portfolio timeseries

### DIFF
--- a/finary_uapi/__main__.py
+++ b/finary_uapi/__main__.py
@@ -5,6 +5,7 @@ Usage:
     finary_uapi me
     finary_uapi institution_connections
     finary_uapi organizations
+    finary_uapi timeseries <period> <type>
     finary_uapi checking_accounts transactions
     finary_uapi fonds_euro
     finary_uapi startups
@@ -97,6 +98,7 @@ from .user_portfolio import (
     get_portfolio_crowdlendings_distribution,
     get_portfolio_cryptos_distribution,
     get_portfolio_credit_accounts_transactions,
+    get_portfolio_timeseries,
 )
 from .precious_metals import get_precious_metals
 from .user_generic_assets import (
@@ -336,6 +338,8 @@ def main() -> int:  # pragma: nocover
                 result = get_portfolio_investments_transactions(session)
             else:
                 result = get_portfolio_investments(session)
+        elif args["timeseries"]:
+            result = get_portfolio_timeseries(session, args["<period>"], args["<type>"])
         elif args["holdings_accounts"]:
             if args["<account_name>"]:
                 result = get_holdings_account_per_name_or_id(

--- a/finary_uapi/user_portfolio.py
+++ b/finary_uapi/user_portfolio.py
@@ -37,15 +37,15 @@ def get_portfolio_investments(session: requests.Session):
     return get_portfolio(session, "investments")
 
 
-def get_portfolio_timeseries(
-    session: requests.Session, portfolio_type: str, period: str, type: str
-):
+def get_portfolio_timeseries(session: requests.Session, period: str, type: str):
     """
-    `portfolio_type` is  "investments", "cryptos", "crowdlendings"
-    `period` can be "all", "1w", "1m", "ytd", "1y", it not specified, Finary will use "all"
+    `period` can be "all", "1w", "1m", "ytd", "1y". If not specified, Finary will use "all"
+    `type` can be "gross", "net", "finary" (aka financial)
     """
-    url = f"{portfolio_api}/{portfolio_type}/timeseries"
+    url = f"{portfolio_api}/timeseries"
     params = {}
+    if type:
+        params["type"] = type
     if period:
         params["period"] = period
     x = session.get(url, params=params)


### PR DESCRIPTION
Hey, looks like the previous `dashboard` API endpoint doesn't exist anymore, so we need to access the history of portfolio amounts through `portfolio/timeseries`.

I've fixed the current `get_portfolio_timeseries` method and exposed it to the CLI for good measure. Feel free to refactor if needed.

Could you please publish a new PyPI version with these changes? Thanks!